### PR TITLE
feat(backend): コーヒー豆リスト取得APIの実装

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,6 @@
     "name": "Coffee Beans Project",
     "dockerComposeFile": "../docker-compose.yml",
     "service": "frontend",
-    "workspaceFolder": "/app",
+    "workspaceFolder": "/workspaces/coffeebeans",
     "shutdownAction": "stopCompose"
   }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,5 @@
 module coffee-beans-project/backend
 
 go 1.24.4
+
+require github.com/rs/cors v1.11.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,2 @@
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=

--- a/backend/main.go
+++ b/backend/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"github.com/rs/cors"
 )
 
 // コーヒー豆のデータ構造を定義する
@@ -36,14 +37,25 @@ func getBeansHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	// ルートURLへのアクセスは、サーバーが動いていることを確認するために残しておく
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+
+	mux := http.NewServeMux() // httpルーターをmuxとして定義
+
+	// ルートURLへのアクセス
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Backend server is running!")
 	})
 
-	// 新しいAPIエンドポイントを登録
-	http.HandleFunc("/api/beans", getBeansHandler)
+	// APIエンドポイントを登録
+	mux.HandleFunc("/api/beans", getBeansHandler)
+
+	// ▼▼▼ CORS設定を追加 ▼▼▼
+	handler := cors.New(cors.Options{
+		AllowedOrigins: []string{"http://localhost:5173"}, // フロントエンドのURLを許可
+		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedHeaders: []string{"Content-Type"},
+	}).Handler(mux)
+	// ▲▲▲ ここまで ▲▲▲
 
 	fmt.Println("Backend server is running on http://localhost:8080")
-	log.Fatal(http.ListenAndServe(":8080", nil))
+	log.Fatal(http.ListenAndServe(":8080", handler))
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -2,19 +2,48 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 )
 
+// コーヒー豆のデータ構造を定義する
+type Bean struct {
+	ID     int    `json:"id"`
+	Name   string `json:"name"`
+	Origin string `json:"origin"`
+	Price  int    `json:"price"`
+}
+
+// ダミーデータのリスト（仮のデータベース）
+var beans = []Bean{
+	{ID: 1, Name: "エチオピア イルガチェフェ", Origin: "エチオピア", Price: 1200},
+	{ID: 2, Name: "ブラジル サントスNo.2", Origin: "ブラジル", Price: 800},
+	{ID: 3, Name: "グアテマラ SHB", Origin: "グアテマラ", Price: 1000},
+}
+
+// GET /api/beans のリクエストを処理するハンドラ
+func getBeansHandler(w http.ResponseWriter, r *http.Request) {
+	// レスポンスの形式がJSONであることをヘッダーで指定
+	w.Header().Set("Content-Type", "application/json")
+
+	// beansスライスをJSONに変換してレスポンスとして書き出す
+	if err := json.NewEncoder(w).Encode(beans); err != nil {
+		// JSONへの変換でエラーが起きたら、サーバーエラーを返す
+		http.Error(w, "Failed to encode beans to JSON", http.StatusInternalServerError)
+	}
+}
+
 func main() {
-	// ルートURL ("/") へのアクセスがあった場合に、メッセージを返す
+	// ルートURLへのアクセスは、サーバーが動いていることを確認するために残しておく
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "Hello from Go Backend!")
+		fmt.Fprintf(w, "Backend server is running!")
 	})
 
-	// サーバー起動のログを出力
+	// 新しいAPIエンドポイントを登録
+	http.HandleFunc("/api/beans", getBeansHandler)
+
 	fmt.Println("Backend server is running on http://localhost:8080")
-	// 8080ポートでサーバーを起動
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -1,0 +1,54 @@
+// backend/main_test.go
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect" // データを深く比較するために追加
+	"testing"
+)
+
+// TestGetBeansHandler は getBeansHandler のテスト関数です
+func TestGetBeansHandler(t *testing.T) {
+	// --- 準備 (Arrange) ---
+
+	// テスト用のHTTPリクエストを作成
+	// GETメソッドで "/api/beans" を呼び出すリクエスト
+	req, err := http.NewRequest("GET", "/api/beans", nil)
+	if err != nil {
+		t.Fatalf("リクエストの作成に失敗しました: %v", err)
+	}
+
+	// レスポンスを記録するためのレコーダーを作成
+	// これが、テスト中の「偽のブラウザ」の役割をします
+	rr := httptest.NewRecorder()
+
+	// テスト対象のハンドラを準備
+	handler := http.HandlerFunc(getBeansHandler)
+
+	// --- 実行 (Act) ---
+
+	// 作成したリクエストをハンドラに渡し、レスポンスをレコーダーに記録
+	handler.ServeHTTP(rr, req)
+
+	// --- 検証 (Assert) ---
+
+	// 1. ステータスコードが200 OKか？
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("期待と異なるステータスコードです: got %v want %v", status, http.StatusOK)
+	}
+
+	// 2. レスポンスボディのJSONを、[]Bean のスライスに変換（デコード）してみる
+	var actualBeans []Bean
+	if err := json.NewDecoder(rr.Body).Decode(&actualBeans); err != nil {
+		t.Fatalf("レスポンスボディのJSONデコードに失敗しました: %v", err)
+	}
+
+	// 3. 返ってきたデータの中身は、私たちが定義したダミーデータと一致するか？
+	// reflect.DeepEqual は、スライスや構造体など複雑なデータでも、中身が完全に一致するかを比較してくれます
+	if !reflect.DeepEqual(actualBeans, beans) {
+		t.Errorf("期待と異なるレスポンスボディです: got %v want %v", actualBeans, beans)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,9 @@ services:
     build:
       context: ./frontend
     volumes:
-      - ./frontend:/app
-      - /app/node_modules # node_modulesは同期対象から除外
+      - .:/workspaces/coffeebeans:cached
+      - /workspaces/coffeebeans/frontend/node_modules # <--- node_modulesのパスを更新
+
     ports:
       - "5173:5173"
 


### PR DESCRIPTION
## 概要

コーヒー豆の一覧を返すAPIを実装しました。
これにより、フロントエンドが必要とするデータソースの準備が整います。

## 関連イシュー

Closes #9

## 変更点

-   `backend/main.go`に`Bean`構造体を定義しました。
-   APIが返すためのダミーデータとして、3件のコーヒー豆リストを作成しました。
-   `GET /api/beans`のエンドポイントと、そのリクエストを処理する`getBeansHandler`を実装しました。
-   **`main_test.go` を作成し、`getBeansHandler` に対する自動テストを実装しました。**

## 確認方法

### 1. 自動テストによる確認 (必須)

PCのターミナル（WSL）から以下のコマンドを実行し、すべてのテストが `PASS` することを確認してください。

```bash
docker compose exec backend sh -c "go test -v"
```

**期待される出力:**
```
=== RUN   TestGetBeansHandler
--- PASS: TestGetBeansHandler (0.00s)
PASS
ok      coffee-beans-project/backend    0.005s
```

### 2. 手動による動作確認 (任意)

念のため、手動でも動作を確認する場合は、以下の手順を実行してください。

1.  `docker compose exec backend sh`でコンテナに入り、`air`コマンドでバックエンドサーバーを起動します。
2.  ブラウザまたはAPIクライアントで `http://localhost:8080/api/beans` に `GET` リクエストを送信します。
3.  期待通りのJSON（3件のコーヒー豆データ）が返ってくることを確認します。

## セルフレビュー

-   [x] `go fmt`でコードがフォーマットされていること
-   [x] 実装に対応するテストコードが書かれていること**
-   [x] イシューで定義された完了条件をすべて満たしていること
-   [x] このプルリクエストに関係のない変更が含まれていないこと