### PR TITLE
feat:コーヒー豆詳細表示コンポーネントの実装

### DIFF
--- a/frontend/src/pages/BeanDetailPage.tsx
+++ b/frontend/src/pages/BeanDetailPage.tsx
@@ -1,14 +1,102 @@
-import { useParams } from 'react-router-dom';
-import { Container, Title, Text } from '@mantine/core';
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import {
+  Container,
+  Title,
+  Text,
+  Paper,
+  Loader,
+  Alert,
+  Center,
+  Button,
+} from '@mantine/core';
+import { IconAlertCircle, IconArrowLeft } from '@tabler/icons-react';
+
+// 表示する豆データの型を定義
+interface BeanDetail {
+  id: number;
+  name: string;
+  origin: string;
+  price: number;
+}
 
 export default function BeanDetailPage() {
-  // URLのパラメータ（:beanId）を取得する
+  // URLからbeanIdを取得
   const { beanId } = useParams();
+
+  // stateを定義
+  const [bean, setBean] = useState<BeanDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // beanIdを使ってAPIを呼び出す
+  useEffect(() => {
+    if (!beanId) return;
+
+    const fetchBeanDetail = async () => {
+      try {
+        setLoading(true);
+        const response = await fetch(`/api/beans/${beanId}`);
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data = await response.json();
+        setBean(data);
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          setError(e.message);
+        } else {
+          setError('不明なエラーが発生しました');
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchBeanDetail();
+  }, [beanId]); // beanIdが変わるたびにAPIを再実行
+
+  if (loading) {
+    return (
+      <Center style={{ height: '100vh' }}>
+        <Loader />
+      </Center>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container mt="xl">
+        <Alert icon={<IconAlertCircle size="1rem" />} title="エラー" color="red">
+          データの取得に失敗しました: {error}
+        </Alert>
+      </Container>
+    );
+  }
 
   return (
     <Container mt="xl">
-      <Title order={1}>コーヒー豆詳細ページ</Title>
-      <Text mt="md">表示している豆のID: {beanId}</Text>
+      <Button
+        component={Link}
+        to="/"
+        leftSection={<IconArrowLeft size={14} />}
+        variant="subtle"
+        mb="md"
+      >
+        一覧に戻る
+      </Button>
+
+      {bean && (
+        <Paper shadow="sm" p="lg" radius="md" withBorder>
+          <Title order={1}>{bean.name}</Title>
+          <Text size="lg" c="dimmed" mt="xs">
+            産地: {bean.origin}
+          </Text>
+          <Text size="xl" fw={700} mt="md">
+            {bean.price}円
+          </Text>
+        </Paper>
+      )}
     </Container>
   );
 }

--- a/frontend/src/pages/BeanListPage.test.tsx
+++ b/frontend/src/pages/BeanListPage.test.tsx
@@ -6,20 +6,31 @@ import BeanListPage from './BeanListPage';
 import BeanDetailPage from './BeanDetailPage';
 import { MantineProvider } from '@mantine/core';
 
-// APIのモック設定
-const mockBeans = [{ id: 1, name: 'モック・ブルーマウンテン' }];
+// --- APIのモック設定を修正 ---
+const mockBeanList = [{ id: 1, name: 'モック・ブルーマウンテン' }];
+const mockBeanDetail = { id: 1, name: '詳細・ブルーマウンテン', origin: 'モック産地', price: 1200 };
+
 beforeAll(() => {
-  globalThis.fetch = vi.fn().mockResolvedValue({
-    ok: true,
-    json: () => Promise.resolve(mockBeans),
+  // fetchが呼ばれたURLに応じて、返すダミーデータを切り替える
+  globalThis.fetch = vi.fn((url) => {
+    let body;
+    if (url === '/api/beans') {
+      body = JSON.stringify(mockBeanList);
+    } else if (url.toString().startsWith('/api/beans/')) {
+      body = JSON.stringify(mockBeanDetail);
+    }
+
+    return Promise.resolve(new Response(body, {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
   });
 });
+
 afterEach(() => vi.clearAllMocks());
 afterAll(() => vi.restoreAllMocks());
 
-
 test('リストの項目をクリックすると、対応する詳細ページに遷移する', async () => {
-  // テスト用のルーターを設定
   render(
     <MantineProvider>
       <MemoryRouter initialEntries={['/']}>
@@ -31,15 +42,15 @@ test('リストの項目をクリックすると、対応する詳細ページ�
     </MantineProvider>
   );
 
-  // APIから取得したリスト項目が表示されるのを待つ
+  // 一覧ページのリスト項目が表示されるのを待つ
   const linkElement = await screen.findByText('モック・ブルーマウンテン');
   expect(linkElement).toBeInTheDocument();
 
-  // ユーザーがリンクをクリックする操作をシミュレート
+  // リンクをクリック
   await userEvent.click(linkElement);
 
-  // 詳細ページに表示されるはずのテキストが表示されていることを確認
-  // これにより、画面遷移が成功したことがわかる
-  expect(await screen.findByText('コーヒー豆詳細ページ')).toBeInTheDocument();
-  expect(screen.getByText('表示している豆のID: 1')).toBeInTheDocument();
+  // --- 検証部分を修正 ---
+  // 遷移後の詳細ページで、詳細APIから取得したデータが表示されるのを待つ
+  expect(await screen.findByText(mockBeanDetail.name)).toBeInTheDocument();
+  expect(screen.getByText(`産地: ${mockBeanDetail.origin}`)).toBeInTheDocument();
 });


### PR DESCRIPTION
#### コーヒー豆一覧画面からクリックした際に表示されるコーヒー豆詳細画面コンポーネントBeanDetailPage.tsxを修正しました。 
#### 併せて、ユニットテストファイルのBeanDetailPage.test.tsxも修正しました。


### 動作確認
#### バックエンドサーバーの起動 PCの新しいターミナル (WSL) からbackendコンテナに入り、airを起動します。

backendコンテナに入る(Bash)
```
docker compose exec backend sh
```


airを起動（Bash）
```
air
```

#### フロントエンドサーバーの起動 VSCode内のターミナルで、開発サーバーを起動します。

```bash
npm run dev
```

PCのブラウザで `http://localhost:5173` を開き、一覧画面から各詳細ページに遷移、サンプルデータのコーヒー豆名称、産地、価格が表示されることを確認してください。

### 3\. 自動テストの動作確認

最後に、ユニットテストがパスすることを確認します。
`npm run dev`が実行中のターミナルとは**別のターミナルを開き**（ターミナルパネルの`+`アイコンで追加できます）、以下のコマンドを実行します。

```bash
npm test
```

全てのテストが `PASS` することを確認してください。

-----

以上で、全ての動作確認は完了です。