### PR TITLE
feat(backend): Supabaseへの接続設定とリポジトリ層を実装 (Closes #19)

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,3 +3,5 @@ module coffee-beans-project/backend
 go 1.24.4
 
 require github.com/rs/cors v1.11.1
+
+require github.com/supabase-community/postgrest-go v0.0.11

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,2 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
+github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/supabase-community/postgrest-go v0.0.11 h1:717GTUMfLJxSBuAeEQG2MuW5Q62Id+YrDjvjprTSErg=
+github.com/supabase-community/postgrest-go v0.0.11/go.mod h1:cw6LfzMyK42AOSBA1bQ/HZ381trIJyuui2GWhraW7Cc=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/backend/main.go
+++ b/backend/main.go
@@ -5,9 +5,16 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os" // .envファイルを読み込むために追加
 
 	"github.com/rs/cors"
+	"github.com/supabase-community/postgrest-go" // Supabaseクライアントを追加
 )
+
+// Api構造体にStoreを持たせる準備
+// type Api struct {
+// 	store *Store
+// }
 
 // newRouter は、このアプリケーションのすべてのルートを含むルーターをセットアップして返す
 func newRouter() http.Handler {
@@ -30,6 +37,27 @@ func newRouter() http.Handler {
 }
 
 func main() {
+	// .envからSupabaseの情報を取得
+	supabaseURL := os.Getenv("SUPABASE_URL")
+	supabaseKey := os.Getenv("SUPABASE_SERVICE_KEY")
+	if supabaseURL == "" || supabaseKey == "" {
+		log.Fatal("環境変数 SUPABASE_URL と SUPABASE_SERVICE_KEY を設定してください")
+	}
+
+	// SupabaseクライアントとStoreを初期化
+	headers := map[string]string{
+		"apikey":        supabaseKey,
+		"Authorization": "Bearer " + supabaseKey,
+	}
+	client := postgrest.NewClient(supabaseURL+"/rest/v1", "", headers)
+	_ = NewStore(client) // store変数はまだ使わないので、`_`で受け取る
+	//store := NewStore(client)
+
+	log.Println("Successfully initialized Supabase client!") // 接続準備ができたことをログに出力
+
+	// Apiインスタンスを作成（今後のための準備）
+	// api := &Api{store: store}
+
 	handler := newRouter()
 	fmt.Println("Backend server is running on http://localhost:8080")
 	log.Fatal(http.ListenAndServe(":8080", handler))

--- a/backend/store.go
+++ b/backend/store.go
@@ -1,0 +1,13 @@
+package main
+
+import postgrest "github.com/supabase-community/postgrest-go"
+
+// Store はデータベースクライアントを保持します
+type Store struct {
+	client *postgrest.Client
+}
+
+// NewStore は新しいStoreインスタンスを作成します
+func NewStore(client *postgrest.Client) *Store {
+	return &Store{client: client}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,5 @@ services:
       - ./backend:/app
     ports:
       - "8080:8080"
+    env_file:
+      - ./.env


### PR DESCRIPTION
## 概要

第2スプリントの目標であるデータベース導入に向け、GoバックエンドとSupabaseを接続するための設定を追加しました。
これにより、次のタスク(#20)でAPIのデータソースをDBに切り替える準備が整いました。

## 関連イシュー

Closes #19

## 変更点

-   `postgrest-go` ライブラリをプロジェクトに追加 (`go.mod`, `go.sum`を更新)。
-   `.env` ファイルから `SUPABASE_URL` と `SUPABASE_SERVICE_KEY` を読み込む処理を `main.go` に追加しました。
-   読み込んだ情報を使って `postgrest.Client` を初期化し、接続が成功したことをログに出力するようにしました。
-   今後のデータベース操作ロジックの置き場所として `store.go` を作成し、`Store` 構造体の雛形を定義しました。
-   `docker-compose.yml` に `env_file` を追加し、コンテナに環境変数が渡されるように修正しました。

## 確認方法

1.  ローカルの `.env` ファイルに正しいSupabaseのURLとキーが設定されていることを確認します。
2.  このブランチで `docker compose up -d` を実行し、コンテナを起動します。
3.  `docker compose logs -f backend` で `backend` サービスのログを確認します。
4.  ログの中に `Successfully initialized Supabase client!` というメッセージが表示されることを確認します。
5.  `docker compose exec backend sh -c "go test -v"` を実行し、既存のテストが（APIの挙動は変わっていないため）引き続きPASSすることを確認します。

## セルフレビュー

-   [x] `go fmt`でコードがフォーマットされていること
-   [x] `.env`ファイルに直接キーを書き込むなど、秘密情報がコミットに含まれていないこと
-   [x] イシューで定義された完了条件を満たしていること