### PR TITLE
feat(backend): 新規で豆データを登録するAPIを実装 (Closes #21)

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -55,7 +55,8 @@ func main() {
 	// ルーティング設定を、apiのメソッドを呼び出すように変更
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", api.healthCheckHandler)
-	mux.HandleFunc("/api/beans", api.getBeansHandler)
+	mux.HandleFunc("GET /api/beans", api.getBeansHandler)
+	mux.HandleFunc("POST /api/beans", api.createBeanHandler)
 	mux.HandleFunc("/api/beans/{id}", api.getBeanHandler)
 
 	// CORS設定


### PR DESCRIPTION
## 概要
新規で豆データを登録するAPIを実装しました。

## 関連イシュー

Closes #21

## 変更点

- コーヒー豆のデータを新規登録するためのPOST /api/beansエンドポイントを実装

- `store.go`にDBにデータを挿入する`CreateBean`を実装。
- `handlers.go`にリクエストを受け取り、DB登録を呼び出す`createBeanHandler`を実装。 `main.go`に新しいエンドポイントのルーティングを追加。

また、テストの独立性を担保するため、テスト実行方法を全体的にリファクタリング。
各テストが独立したDBトランザクション内で実行され、テスト後にロールバックされるように修正。
これにより、テストデータがDBに残留することがなくなります。

## 確認方法

### 1. 自動テストによる確認 (必須)

PCのターミナル（WSL）から以下のコマンドを実行し、すべてのテストが `PASS` することを確認してください。

```bash
docker compose exec backend sh -c "go test -v"
```

### 2. 手動による動作確認 (任意)

 

### ステップ1: アプリケーションの起動

まず、バックエンドサーバーを起動します。ターミナルで以下のコマンドを実行してください。

```bash
docker compose up -d backend
```


### ステップ2: 新しいコーヒー豆の登録 (POSTリクエスト)

次に、curl コマンドを使って、新しいコーヒー豆のデータを登録するリクエストを送信します。このコマンドは、アプリケーションの `/api/beans` エンドポイントに対して POST リクエストを送ります。

```bash
curl -X POST http://localhost:8080/api/beans \
-H "Content-Type: application/json" \
-d '{"name": "テスト豆", "origin": "日本", "price": 1200, "process": "natural", "roast_profile": "medium"}'
```

成功すると、以下のように登録されたデータ（idなどが付与された状態）がJSON形式で返ってきます。

```json
{"id":1,"created_at":"...","updated_at":"...","name":"テスト豆","origin":"日","price":1200,"process":"natural","roast_profile":"medium"}
```

(idの値は環境によって異なります)

## 登録データの確認(データベースの直接確認)

Supabaseの管理画面にてテストデータが追加されていることを確認してください。(不要であればテストデータは削除してください。)