### PR TITLE
feat(frontend): 認証状態のグローバル管理(Closes #34)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -34,13 +34,13 @@ const renderWithProviders = (initialEntries: string[]) => {
   );
 };
 
-test('ルートパスにアクセスすると、コーヒー豆の一覧ページが表示される', async () => {
+test('ルートパスにアクセスすると、ヘッダーとコーヒー豆の一覧が表示される', async () => {
   renderWithProviders(['/']);
 
-  const listTitle = await screen.findByText(/コーヒー豆リスト/i);
+  const mainTitle = await screen.findByText(/コーヒー豆アプリ/i);
   const firstItem = await screen.findByText('モック・ブルーマウンテン');
 
-  expect(listTitle).toBeInTheDocument();
+  expect(mainTitle).toBeInTheDocument();
   expect(firstItem).toBeInTheDocument();
 });
 
@@ -51,4 +51,11 @@ test('未ログインで/beans/newにアクセスすると、ログインペー�
   await waitFor(() => {
     expect(screen.getByText('Welcome back!')).toBeInTheDocument();
   });
+});
+
+test('/loginパスにアクセスした際、ヘッダーが表示されない', () => {
+  renderWithProviders(['/login']);
+
+  const heading = screen.queryByRole('heading', { name: 'コーヒー豆アプリ' });
+  expect(heading).not.toBeInTheDocument();
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,21 +5,24 @@ import NewBeanPage from './pages/NewBeanPage';
 import Login from './pages/Login';
 import { useAuth } from './contexts/AuthContext';
 import { useEffect } from 'react';
+import Layout from './components/Layout';
 
 const App = () => {
   return (
     <Routes>
-      <Route path="/" element={<BeanListPage />} />
       <Route path="/login" element={<Login />} />
-      <Route path="/beans/:beanId" element={<BeanDetailPage />} />
-      <Route
-        path="/beans/new"
-        element={
-          <RequireAuth>
-            <NewBeanPage />
-          </RequireAuth>
-        }
-      />
+      <Route path="/" element={<Layout />}>
+        <Route index element={<BeanListPage />} />
+        <Route path="beans/:beanId" element={<BeanDetailPage />} />
+        <Route
+          path="beans/new"
+          element={
+            <RequireAuth>
+              <NewBeanPage />
+            </RequireAuth>
+          }
+        />
+      </Route>
     </Routes>
   );
 };

--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { test, expect, vi, afterEach } from 'vitest';
+import { MantineProvider } from '@mantine/core';
+import { AuthProvider } from '../contexts/AuthContext';
+import Header from './Header';
+import { Session } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabaseClient';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(
+    <MemoryRouter>
+      <MantineProvider>
+        <AuthProvider>{ui}</AuthProvider>
+      </MantineProvider>
+    </MemoryRouter>
+  );
+};
+
+test('未ログイン時、ログインボタンが表示され、登録ボタンが非表示であること', async () => {
+  vi.spyOn(supabase.auth, 'getSession').mockResolvedValue({ data: { session: null }, error: null });
+  vi.spyOn(supabase.auth, 'onAuthStateChange').mockImplementation((callback) => {
+    callback('INITIAL_SESSION', null);
+    return {
+      data: { subscription: { unsubscribe: vi.fn() } },
+    };
+  });
+
+  renderWithProviders(<Header />);
+  
+  expect(screen.getByRole('button', { name: /ログイン/i })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /新しい豆を登録/i })).not.toBeInTheDocument();
+});
+
+test('ログイン時、ユーザー情報とログアウト・登録ボタンが表示されること', async () => {
+  const mockSession: Session = {
+    access_token: 'mock-access-token',
+    refresh_token: 'mock-refresh-token',
+    expires_in: 3600,
+    token_type: 'bearer',
+    user: {
+      id: '1',
+      app_metadata: {},
+      user_metadata: {},
+      aud: 'authenticated',
+      email: 'test@example.com',
+      created_at: new Date().toISOString(),
+    },
+  };
+  vi.spyOn(supabase.auth, 'getSession').mockResolvedValue({ data: { session: mockSession }, error: null });
+  vi.spyOn(supabase.auth, 'onAuthStateChange').mockImplementation((callback) => {
+    callback('SIGNED_IN', mockSession);
+    return {
+      data: { subscription: { unsubscribe: vi.fn() } },
+    };
+  });
+  
+  renderWithProviders(<Header />);
+
+  expect(await screen.findByText('test@example.com')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /ログアウト/i })).toBeInTheDocument();
+  expect(screen.getByText(/新しい豆を登録/i)).toBeInTheDocument();
+});

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,36 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { Title, Button, Group, Text } from '@mantine/core';
+import { useAuth } from '../contexts/AuthContext';
+import { supabase } from '../lib/supabaseClient';
+
+const Header = () => {
+  const { session } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+  };
+
+  return (
+    <Group justify="space-between" mb="lg">
+      <Title order={1}>
+        <Link to="/" style={{ textDecoration: 'none', color: 'inherit' }}>
+          コーヒー豆アプリ
+        </Link>
+      </Title>
+      {session ? (
+        <Group>
+          <Text>{session.user.email}</Text>
+          <Button onClick={handleLogout}>ログアウト</Button>
+          <Button component={Link} to="/beans/new">
+            新しい豆を登録
+          </Button>
+        </Group>
+      ) : (
+        <Button onClick={() => navigate('/login')}>ログイン</Button>
+      )}
+    </Group>
+  );
+};
+
+export default Header;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,16 @@
+import { Outlet } from 'react-router-dom';
+import { Container } from '@mantine/core';
+import Header from './Header';
+
+const Layout = () => {
+  return (
+    <Container mt="xl">
+      <Header />
+      <main>
+        <Outlet />
+      </main>
+    </Container>
+  );
+};
+
+export default Layout;

--- a/frontend/src/pages/BeanListPage.test.tsx
+++ b/frontend/src/pages/BeanListPage.test.tsx
@@ -1,13 +1,11 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { beforeAll, afterEach, afterAll, test, expect, vi } from 'vitest';
+import { beforeAll, test, expect, vi } from 'vitest';
 import BeanListPage from './BeanListPage';
 import BeanDetailPage from './BeanDetailPage';
 import { MantineProvider } from '@mantine/core';
 import { AuthProvider } from '../contexts/AuthContext';
-import { Session } from '@supabase/supabase-js';
-import { supabase } from '../lib/supabaseClient';
 
 // --- APIのモック設定 ---
 const mockBeanList = [{ id: 1, name: 'モック・ブルーマウンテン' }];
@@ -16,7 +14,7 @@ const mockBeanDetail = { id: 1, name: '詳細・ブルーマウンテン', origi
 beforeAll(() => {
   globalThis.fetch = vi.fn((url) => {
     let body;
-    if (url === '/api/beans') {
+    if (url.toString().endsWith('/api/beans')) {
       body = JSON.stringify(mockBeanList);
     } else if (url.toString().startsWith('/api/beans/')) {
       body = JSON.stringify(mockBeanDetail);
@@ -27,8 +25,6 @@ beforeAll(() => {
     }));
   });
 });
-
-
 
 // テスト用のレンダリング関数
 const renderWithProviders = (ui: React.ReactElement, initialEntries = ['/']) => {
@@ -45,46 +41,6 @@ const renderWithProviders = (ui: React.ReactElement, initialEntries = ['/']) => 
     </MantineProvider>
   );
 };
-
-test('未ログイン時、ログインボタンが表示され、登録ボタンが非表示であること', async () => {
-  renderWithProviders(<BeanListPage />);
-  // ローディングが終わるのを待つ
-  await screen.findByText('モック・ブルーマウンテン');
-  
-  expect(screen.getByRole('button', { name: /ログイン/i })).toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: /新しい豆を登録/i })).not.toBeInTheDocument();
-});
-
-test('ログイン時、ユーザー情報とログアウト・登録ボタンが表示されること', async () => {
-  // ログイン状態をモック
-  const mockSession: Session = {
-    access_token: 'mock-access-token',
-    refresh_token: 'mock-refresh-token',
-    expires_in: 3600,
-    token_type: 'bearer',
-    user: {
-      id: '1',
-      app_metadata: {},
-      user_metadata: {},
-      aud: 'authenticated',
-      email: 'test@example.com',
-      created_at: new Date().toISOString(),
-    },
-  };
-  vi.spyOn(supabase.auth, 'getSession').mockResolvedValue({ data: { session: mockSession }, error: null });
-  vi.spyOn(supabase.auth, 'onAuthStateChange').mockImplementation((callback) => {
-    callback('SIGNED_IN', mockSession);
-    return {
-      data: { subscription: { unsubscribe: vi.fn() } },
-    };
-  });
-  
-  renderWithProviders(<BeanListPage />);
-
-  expect(await screen.findByText('test@example.com')).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /ログアウト/i })).toBeInTheDocument();
-  expect(screen.getByText(/新しい豆を登録/i)).toBeInTheDocument();
-});
 
 test('リストの項目をクリックすると、対応する詳細ページに遷移する', async () => {
   renderWithProviders(<BeanListPage />);

--- a/frontend/src/pages/BeanListPage.tsx
+++ b/frontend/src/pages/BeanListPage.tsx
@@ -1,20 +1,16 @@
 import { useEffect, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import {
   Container,
-  Title,
   List,
   Loader,
   Alert,
   Center,
   ThemeIcon,
   Text,
-  Button,
-  Group,
+  Title,
 } from '@mantine/core';
 import { IconAlertCircle, IconCoffee } from '@tabler/icons-react';
-import { useAuth } from '../contexts/AuthContext';
-import { supabase } from '../lib/supabaseClient';
 
 interface Bean {
   id: number;
@@ -25,8 +21,6 @@ export default function BeanListPage() {
   const [beans, setBeans] = useState<Bean[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  const { session } = useAuth();
-  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchBeans = async () => {
@@ -50,10 +44,6 @@ export default function BeanListPage() {
     fetchBeans();
   }, []);
 
-  const handleLogout = async () => {
-    await supabase.auth.signOut();
-  };
-
   if (loading) {
     return (
       <Center style={{ height: '100vh' }}>
@@ -74,43 +64,25 @@ export default function BeanListPage() {
   }
 
   return (
-    <Container mt="xl">
-      <Group justify="space-between" mb="lg">
-        <Title order={1}>
-          コーヒー豆リスト
-        </Title>
-        {session ? (
-          <Group>
-            <Text>{session.user.email}</Text>
-            <Button onClick={handleLogout}>ログアウト</Button>
-            <Button component={Link} to="/beans/new">
-              新しい豆を登録
-            </Button>
-          </Group>
-        ) : (
-          <Button onClick={() => navigate('/login')}>ログイン</Button>
-        )}
-      </Group>
-      <List
-        spacing="xs"
-        size="sm"
-        center
-        icon={
-          <ThemeIcon color="teal" size={24} radius="xl">
-            <IconCoffee size="1rem" />
-          </ThemeIcon>
-        }
-      >
-        {beans.map((bean) => (
-          <List.Item key={bean.id}>
-            <Link to={`/beans/${bean.id}`} style={{ textDecoration: 'none' }}>
-              <Text component="span" c="blue.7">
-                {bean.name}
-              </Text>
-            </Link>
-          </List.Item>
-        ))}
-      </List>
-    </Container>
+    <List
+      spacing="xs"
+      size="sm"
+      center
+      icon={
+        <ThemeIcon color="teal" size={24} radius="xl">
+          <IconCoffee size="1rem" />
+        </ThemeIcon>
+      }
+    >
+      {beans.map((bean) => (
+        <List.Item key={bean.id}>
+          <Link to={`/beans/${bean.id}`} style={{ textDecoration: 'none' }}>
+            <Text component="span" c="blue.7">
+              {bean.name}
+            </Text>
+          </Link>
+        </List.Item>
+      ))}
+    </List>
   );
 }

--- a/frontend/src/pages/Login.test.tsx
+++ b/frontend/src/pages/Login.test.tsx
@@ -1,19 +1,86 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { test, expect, vi } from 'vitest';
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
 import Login from './Login';
 import { MantineProvider } from '@mantine/core';
 import { supabase } from '../lib/supabaseClient';
+import { AuthProvider } from '../contexts/AuthContext';
+import { Session } from '@supabase/supabase-js';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(supabase.auth.getSession).mockResolvedValue({ data: { session: null }, error: null });
+  vi.mocked(supabase.auth.onAuthStateChange).mockImplementation((callback) => {
+    callback('INITIAL_SESSION', null);
+    return {
+      data: { subscription: { unsubscribe: vi.fn() } },
+    };
+  });
+});
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
 
 // テスト用のレンダリング関数
 const renderWithProviders = (ui: React.ReactElement) => {
   return render(
-    <MemoryRouter>
-      <MantineProvider>{ui}</MantineProvider>
-    </MemoryRouter>
+    <MantineProvider>
+      <AuthProvider>
+        <MemoryRouter>
+          {ui}
+        </MemoryRouter>
+      </AuthProvider>
+    </MantineProvider>
   );
 };
+
+test('未ログインのユーザーにはログインフォームが表示される', async () => {
+  renderWithProviders(<Login />);
+  expect(screen.getByLabelText('Email')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'ログインリンクを送る' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Googleでログイン' })).toBeInTheDocument();
+});
+
+test('ログイン済みのユーザーはホームページにリダイレクトされる', async () => {
+  const mockSession: Session = {
+    access_token: 'mock-access-token',
+    refresh_token: 'mock-refresh-token',
+    expires_in: 3600,
+    token_type: 'bearer',
+    user: {
+      id: '1',
+      app_metadata: {},
+      user_metadata: {},
+      aud: 'authenticated',
+      email: 'test@example.com',
+      created_at: new Date().toISOString(),
+    },
+  };
+  vi.mocked(supabase.auth.getSession).mockResolvedValue({ data: { session: mockSession }, error: null });
+  vi.mocked(supabase.auth.onAuthStateChange).mockImplementation((callback) => {
+    callback('SIGNED_IN', mockSession);
+    return {
+      data: { subscription: { unsubscribe: vi.fn() } },
+    };
+  });
+
+  renderWithProviders(<Login />);
+
+  await waitFor(() => {
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+  });
+});
 
 test('無効なメールアドレスを入力して送信するとエラーメッセージが表示される', async () => {
   renderWithProviders(<Login />);

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import {
   TextInput,
@@ -12,6 +12,8 @@ import {
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconMail } from '@tabler/icons-react';
+import { useAuth } from '../contexts/AuthContext';
+import { useNavigate } from 'react-router-dom';
 
 function GoogleIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
   return (
@@ -25,9 +27,17 @@ function GoogleIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
 }
 
 const Login = () => {
+  const { session } = useAuth();
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState('');
   const [messageType, setMessageType] = useState<'success' | 'error' | null>(null);
+
+  useEffect(() => {
+    if (session) {
+      navigate('/', { replace: true });
+    }
+  }, [session, navigate]);
 
   const form = useForm({
     initialValues: {


### PR DESCRIPTION
## 概要
認証状態のグローバル管理に関する実装

## 関連イシュー

Closes #34

## 変更点

- ナビゲーションバーを共通ヘッダとして実装
- ログイン状態に応じて共通ヘッダの表示項目を変更(共通ヘッダ導入に伴い、コーヒー豆一覧画面から実装を移動)  
  
**認証状態のグローバル管理を実現するAuthProvider等の実装は#32で実装済みでした**

## 確認方法

### 1. 自動テストによる確認 (必須)

バックエンドサーバを起動後、VScodeにてフロントエンドの'npm test'を実行
すべてPASSすることを確認してください。

### 2. 手動による動作確認 (任意)

 画面表示上の変更点は特にありません。
(コーヒー豆一覧のヘッダが共通ヘッダ化された程度なので、見た目上は同じです)
デグレがないことを簡単に確認お願いします。

