### PR TITLE
feat(backend): JWT認証ミドルウェアを実装 (Closes #35)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 # GoバックエンドのDBダイレクト接続用 (pgx)
 DATABASE_URL="postgresql://postgres:[YOUR-PASSWORD]@db.xxxxxxxx.supabase.com:6543/postgres?prefer_simple_protocol=true"
 
-# --- 将来、Supabaseの他機能（認証、ストレージ等）で利用 ---
-# フロントエンドでの利用や、バックエンドからの管理操作で必要になる可能性があります
-
 # Supabase REST APIのエンドポイントURL
 VITE_SUPABASE_URL="YOUR_SUPABASE_URL"
 
 # Supabaseのサービスロールキー（サーバーサイドでの管理者権限用）
 VITE_SUPABASE_ANON_KEY="YOUR_SUPABASE_SERVICE_ROLE_KEY"
+
+# SupabaseのJWTキー（ ユーザーがログインした際に発行されるトークンが本物かどうかを検証するための秘密鍵）
+SUPABASE_JWT_SECRET="YOUR_SUPABASE_JWT_SECRET"

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,7 @@ go 1.24.4
 require github.com/rs/cors v1.11.1
 
 require (
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/joho/godotenv v1.5.1
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/backend/main.go
+++ b/backend/main.go
@@ -59,6 +59,14 @@ func main() {
 	mux.HandleFunc("POST /api/beans", api.createBeanHandler)
 	mux.HandleFunc("/api/beans/{id}", api.getBeanHandler)
 
+	// ログイン済みユーザーだけがアクセスできる、テスト用のエンドポイント
+	protectedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID := r.Context().Value("userID")
+		fmt.Fprintf(w, "ようこそ、保護されたエリアへ！あなたのユーザーIDは: %v", userID)
+	})
+	// ハンドラをjwtAuthMiddlewareでラップする
+	mux.Handle("/api/protected", jwtAuthMiddleware(protectedHandler))
+
 	// CORS設定
 	handler := cors.New(cors.Options{
 		AllowedOrigins: []string{"http://localhost:5173"},

--- a/backend/middleware.go
+++ b/backend/middleware.go
@@ -1,0 +1,59 @@
+// backend/middleware.go
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// jwtAuthMiddleware は、JWTを検証するミドルウェアです
+func jwtAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// リクエストヘッダーから "Authorization" を取得
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			http.Error(w, "Authorization header is required", http.StatusUnauthorized)
+			return
+		}
+
+		// ヘッダーが "Bearer <token>" の形式になっているか検証
+		headerParts := strings.Split(authHeader, " ")
+		if len(headerParts) != 2 || headerParts[0] != "Bearer" {
+			http.Error(w, "Invalid Authorization header format", http.StatusUnauthorized)
+			return
+		}
+		tokenString := headerParts[1]
+
+		// トークンをパースして検証
+		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+			// 署名メソッドがHMACであることを確認
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+			}
+			// 環境変数からJWTのシークレットキーを取得
+			secret := os.Getenv("SUPABASE_JWT_SECRET")
+			return []byte(secret), nil
+		})
+
+		// トークンが無効な場合はエラー
+		if err != nil || !token.Valid {
+			http.Error(w, "Invalid token", http.StatusUnauthorized)
+			return
+		}
+
+		// トークンからクレーム（特に "sub" クレーム）を取得し、コンテキストにユーザーIDをセット
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if ok && claims["sub"] != nil {
+			ctx := context.WithValue(r.Context(), "userID", claims["sub"])
+			r = r.WithContext(ctx)
+		}
+
+		// 次のハンドラへ処理を渡す
+		next.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
## 概要

APIエンドポイント保護の基盤となる、JWT認証ミドルウェアを実装しました。
これにより、リクエストが認証済みのユーザーからのものかを検証し、保護されたリソースへのアクセスを制御できるようになります。

## 関連イシュー

Closes #35

## 変更点

-   `golang-jwt/jwt/v5` ライブラリをプロジェクトに追加しました。
-   JWTの署名検証に必要な `SUPABASE_JWT_SECRET` を環境変数として追加しました。
-   `middleware.go` を新規作成し、`jwtAuthMiddleware` を実装しました。
-   ミドルウェアは以下の処理を実行します：
    -   `Authorization: Bearer <token>` ヘッダーの存在と形式をチェック
    -   SupabaseのJWT Secretを使用したトークン署名の検証
    -   トークンが不正、または存在しない場合は `401 Unauthorized` エラーを返す
    -   検証成功後、トークン内の `sub` クレーム（ユーザーID）をリクエストコンテキストに格納

## 確認方法

### 事前準備：環境変数の設定

このプルリクエストをテストするには、事前に以下の環境変数の設定が必要です。

1.  Supabaseダッシュボードの `Settings > JWT Keys > Legacy JWT Secret` から秘密鍵をコピーしてください。
2.  プロジェクトルートの `.env` ファイルに、以下の行を追加（または更新）してください。
    ```.env
    SUPABASE_JWT_SECRET="ここにコピーした秘密鍵を貼り付け"
    ```
3.  コンテナを再起動して、環境変数を読み込ませてください。
    ```bash
    docker compose down && docker compose up -d
    ```

### テスト手順

1.  `air` コマンドでバックエンドサーバーを起動します。
2.  **認証失敗ケースの確認**:
    -   トークンなしでテスト用エンドポイントにアクセスし、`401 Unauthorized` が返ってくることを確認します。
    ```bash
    curl -v http://localhost:8080/api/protected
    ```
3.  **認証成功ケースの確認**:
    -   Supabaseの `JWT Secret` を使って `jwt.io` などで有効なテスト用トークンを生成します。
    -   生成したトークンを使い、`Authorization` ヘッダーを付与してリクエストを送信し、`200 OK` が返ってくることを確認します。
    ```bash
    curl -v -H "Authorization: Bearer <YOUR_JWT_TOKEN>" http://localhost:8080/api/protected
    ```
## セルフレビュー

-   [x] `go fmt`でコードがフォーマットされていること
-   [x] 秘密情報がコミットに含まれていないこと
-   [x] イシューで定義された完了条件を満たしていること