### PR TITLE
feat(backend): コーヒー豆削除APIを実装 (Closes #45)

### DIFF
--- a/backend/store.go
+++ b/backend/store.go
@@ -132,3 +132,23 @@ func (s *Store) UpdateBean(ctx context.Context, id int, userID string, bean *Bea
 
 	return &updatedBean, nil
 }
+
+// DeleteBean は指定されたIDのコーヒー豆の情報を削除します
+func (s *Store) DeleteBean(ctx context.Context, id int, userID string) error {
+	// SQLクエリ: 既存のデータを削除する
+	// WHERE句でidとuser_idの両方をチェックすることで、所有者のみが削除できるようにする
+	query := `DELETE FROM beans WHERE id = $1 AND user_id = $2`
+
+	ct, err := s.db.Exec(ctx, query, id, userID)
+	if err != nil {
+		return err
+	}
+
+	// Execで、1行も影響がなかった場合、それは対象が見つからなかったことを意味する
+	// (IDが違うか、userIDが違う)
+	if ct.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+
+	return nil
+}


### PR DESCRIPTION
## 概要
  コーヒー豆の登録情報を削除するAPI（DELETE /api/beans/{id}）を実装しました。

## 関連イシュー

  Closes #45

## 変更点

   - DELETE /api/beans/{id} のエンドポイントを実装
   - リクエストを処理する deleteBeanHandler を handlers.go に追加
   - データベースからデータを削除し、所有者検証を行う DeleteBean 関数を store.go に追加
   - 上記機能に関する自動テストを main_test.go に追加

## 確認方法

###  1. 自動テストによる確認 (必須)

  バックエンドのコンテナ内で以下のコマンドを実行し、すべてのテストがPASSすることを確認してください。

   1 docker exec -w /app coffeebeans-backend-1 go test -v

###  2. 手動による動作確認 (任意)

  curlコマンドを使用して、DELETE /api/beans/{id}のエンドポイントにリクエストを送信し、データが削除されることを確認してください。

    # {削除したい豆のID} と {JWTトークン} は実際のIDとトークンに置き換えてください
    curl -X DELETE http://localhost:8080/api/beans/{削除したい豆のID} \
    -H "Authorization: Bearer {JWTトークン}"

  成功した場合、ステータスコード 204 No Content が返ってきます。