### PR TITLE
46 featfrontend マイページ出品商品一覧の作成

### DIFF
--- a/backend/store.go
+++ b/backend/store.go
@@ -49,7 +49,7 @@ func (s *Store) GetAllBeans(ctx context.Context) ([]Bean, error) {
 	}
 	defer rows.Close()
 
-	var beans []Bean
+	beans := []Bean{}
 	for rows.Next() {
 		var b Bean
 		// 取得したデータをBean構造体にスキャン
@@ -161,7 +161,7 @@ func (s *Store) GetBeansByUserID(ctx context.Context, userID string) ([]Bean, er
 	}
 	defer rows.Close()
 
-	var beans []Bean
+	beans := []Bean{}
 	for rows.Next() {
 		var b Bean
 		if err := rows.Scan(&b.ID, &b.CreatedAt, &b.UpdatedAt, &b.Name, &b.Origin, &b.Price, &b.Process, &b.RoastProfile, &b.UserID); err != nil {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,9 +2,11 @@ import { Routes, Route, useNavigate } from 'react-router-dom';
 import BeanListPage from './pages/BeanListPage';
 import BeanDetailPage from './pages/BeanDetailPage';
 import NewBeanPage from './pages/NewBeanPage';
+import MyBeansPage from './pages/MyBeansPage';
 import Login from './pages/Login';
 import { useAuth } from './contexts/AuthContext';
 import { useEffect } from 'react';
+import { Center, Loader } from '@mantine/core';
 import Layout from './components/Layout';
 
 const App = () => {
@@ -22,22 +24,42 @@ const App = () => {
             </RequireAuth>
           }
         />
+        <Route
+          path="my-beans"
+          element={
+            <RequireAuth>
+              <MyBeansPage />
+            </RequireAuth>
+          }
+        />
       </Route>
     </Routes>
   );
 };
 
 const RequireAuth = ({ children }: { children: JSX.Element }) => {
-  const { session } = useAuth();
+  const { session, isLoading } = useAuth();
   const navigate = useNavigate();
 
+  
+
   useEffect(() => {
-    if (session === null) {
+    if (!isLoading && !session) {
       navigate('/login', { replace: true });
     }
-  }, [session, navigate]);
+  }, [isLoading, session, navigate]);
 
-  return session ? children : null;
+  // 認証読み込み中、またはセッションがなくリダイレクト待ちの間はローダーを表示
+  if (isLoading || !session) {
+    return (
+      <Center style={{ height: '100vh' }}>
+        <Loader />
+      </Center>
+    );
+  }
+
+  // 読み込みが完了し、セッションが存在する場合のみ子コンポーネントを表示
+  return children;
 };
 
 export default App;

--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -63,5 +63,6 @@ test('ログイン時、ユーザー情報とログアウト・登録ボタン�
 
   expect(await screen.findByText('test@example.com')).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /ログアウト/i })).toBeInTheDocument();
+  expect(screen.getByText(/マイページ/i)).toBeInTheDocument();
   expect(screen.getByText(/新しい豆を登録/i)).toBeInTheDocument();
 });

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -22,6 +22,9 @@ const Header = () => {
         <Group>
           <Text>{session.user.email}</Text>
           <Button onClick={handleLogout}>ログアウト</Button>
+          <Button component={Link} to="/my-beans" variant="outline">
+            マイページ
+          </Button>
           <Button component={Link} to="/beans/new">
             新しい豆を登録
           </Button>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -2,27 +2,30 @@ import { createContext, useContext, useState, useEffect } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import type { Session } from '@supabase/supabase-js';
 
-const AuthContext = createContext<{ session: Session | null }>({ session: null });
+const AuthContext = createContext<{ session: Session | null; isLoading: boolean }>({ session: null, isLoading: true });
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [session, setSession] = useState<Session | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       setSession(session);
+      setIsLoading(false);
     });
 
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
       setSession(session);
+      setIsLoading(false);
     });
 
     return () => subscription.unsubscribe();
   }, []);
 
   return (
-    <AuthContext.Provider value={{ session }}>{children}</AuthContext.Provider>
+    <AuthContext.Provider value={{ session, isLoading }}>{children}</AuthContext.Provider>
   );
 };
 

--- a/frontend/src/pages/MyBeansPage.test.tsx
+++ b/frontend/src/pages/MyBeansPage.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { MantineProvider } from '@mantine/core';
+import { vi } from 'vitest';
+import type { Session } from '@supabase/supabase-js';
+import { AuthProvider } from '../contexts/AuthContext';
+import MyBeansPage from './MyBeansPage';
+import { supabase } from '../lib/supabaseClient';
+
+// supabaseClientのモック
+vi.mock('../lib/supabaseClient');
+
+// fetchのモック
+window.fetch = vi.fn();
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(
+    <BrowserRouter>
+      <MantineProvider>
+        <AuthProvider>{ui}</AuthProvider>
+      </MantineProvider>
+    </BrowserRouter>
+  );
+};
+
+const mockSession: Session = {
+  access_token: 'test-token',
+  refresh_token: 'test-refresh-token',
+  expires_in: 3600,
+  token_type: 'bearer',
+  user: {
+    id: 'test-user-id',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: new Date().toISOString(),
+  },
+};
+
+describe('MyBeansPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // onAuthStateChangeのモックを追加
+    vi.mocked(supabase.auth.onAuthStateChange).mockReturnValue({
+      data: {
+        subscription: {
+          id: 'test-subscription',
+          callback: vi.fn(),
+          unsubscribe: vi.fn(),
+        },
+      },
+    });
+  });
+
+  test('ログイン状態で、登録した豆がない場合にメッセージが表示される', async () => {
+    // ログイン状態をモック
+    vi.mocked(supabase.auth.getSession).mockResolvedValueOnce({
+      data: { session: mockSession },
+      error: null,
+    });
+    // APIレスポンスをモック（空の配列）
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+
+    renderWithProviders(<MyBeansPage />);
+
+    // APIが呼ばれるのを待つ
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/my/beans', {
+        headers: {
+          Authorization: `Bearer ${mockSession.access_token}`,
+        },
+      });
+    });
+
+    // ローディングが消え、メッセージが表示されることを確認
+    expect(
+      screen.getByText('マイページ（出品した豆一覧）')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('登録されている豆はありません。')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: '一覧に戻る' })
+    ).toBeInTheDocument();
+  });
+
+  test('ログイン状態で、登録した豆がある場合に一覧表示される', async () => {
+    const mockBeans = [
+      { id: 1, name: 'My Coffee 1' },
+      { id: 2, name: 'My Coffee 2' },
+    ];
+    // ログイン状態をモック
+    vi.mocked(supabase.auth.getSession).mockResolvedValueOnce({
+      data: { session: mockSession },
+      error: null,
+    });
+    // APIレスポンスをモック
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(mockBeans), { status: 200 })
+    );
+
+    renderWithProviders(<MyBeansPage />);
+
+    // データが表示されるのを待つ
+    await waitFor(() => {
+      expect(screen.getByText('My Coffee 1')).toBeInTheDocument();
+      expect(screen.getByText('My Coffee 2')).toBeInTheDocument();
+    });
+
+    // 編集・削除ボタンが表示されていることを確認
+    expect(screen.getAllByRole('button', { name: '編集' })).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: '削除' })).toHaveLength(2);
+    expect(
+      screen.getByRole('link', { name: '一覧に戻る' })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MyBeansPage.tsx
+++ b/frontend/src/pages/MyBeansPage.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Container,
+  List,
+  Loader,
+  Alert,
+  Center,
+  ThemeIcon,
+  Text,
+  Title,
+  Button,
+  Group,
+} from '@mantine/core';
+import { IconAlertCircle, IconCoffee } from '@tabler/icons-react';
+import { useAuth } from '../contexts/AuthContext';
+
+interface Bean {
+  id: number;
+  name: string;
+}
+
+export default function MyBeansPage() {
+  const { session } = useAuth();
+  const [beans, setBeans] = useState<Bean[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchBeans = async () => {
+      if (!session) {
+        // このページはRequireAuthで保護されているため、通常この状態にはならない
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const response = await fetch('/api/my/beans', {
+          headers: {
+            Authorization: `Bearer ${session.access_token}`,
+          },
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data: Bean[] | null = await response.json();
+        setBeans(data || []); // APIがnullを返した場合も空配列として扱う
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          setError(e.message);
+        } else {
+          setError('不明なエラーが発生しました。');
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchBeans();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session?.access_token]); // sessionオブジェクト全体ではなく、変更されないアクセストークンを依存配列に設定
+
+  if (loading) {
+    return (
+      <Center style={{ height: '100vh' }}>
+        <Loader />
+        <Title order={3} ml="md">
+          ローディング中...
+        </Title>
+      </Center>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container mt="xl">
+        <Alert
+          icon={<IconAlertCircle size="1rem" />}
+          title="エラー"
+          color="red"
+        >
+          データの取得に失敗しました: {error}
+        </Alert>
+      </Container>
+    );
+  }
+
+  return (
+    <Container mt="xl">
+      <Title order={1} mb="lg">
+        マイページ（出品した豆一覧）
+      </Title>
+      <List
+        spacing="md"
+        size="sm"
+        icon={
+          <ThemeIcon color="teal" size={24} radius="xl">
+            <IconCoffee size="1rem" />
+          </ThemeIcon>
+        }
+      >
+        {beans.length > 0 ? (
+          beans.map((bean) => (
+            <List.Item key={bean.id}>
+              <Group justify="space-between">
+                <Link
+                  to={`/beans/${bean.id}`}
+                  style={{ textDecoration: 'none' }}
+                >
+                  <Text component="span" c="blue.7">
+                    {bean.name}
+                  </Text>
+                </Link>
+                <Group>
+                  <Button size="xs" variant="outline">
+                    編集
+                  </Button>
+                  <Button size="xs" variant="outline" color="red">
+                    削除
+                  </Button>
+                </Group>
+              </Group>
+            </List.Item>
+          ))
+        ) : (
+          <Text>登録されている豆はありません。</Text>
+        )}
+      </List>
+      <Group mt="xl">
+        <Button component={Link} to="/" variant="outline">
+          一覧に戻る
+        </Button>
+      </Group>
+    </Container>
+  );
+}


### PR DESCRIPTION
## 概要
認証されたユーザーが自身で登録したコーヒー豆を一覧できるマイページ機能を実装しました。

## 関連イシュー
Closes #47

## 変更点
- `/my-beans` ルートを `frontend/src/App.tsx` に追加し、マイページコンポーネントをルーティング。
- ヘッダー (`frontend/src/components/Header.tsx`) に、ログイン時のみ表示される「マイページ」ボタンを追加。
- マイページ (`frontend/src/pages/MyBeansPage.tsx`) およびそのテスト (`frontend/src/pages/MyBeansPage.test.tsx`) を新規作成。
- `RequireAuth` コンポーネントを改善し、セッション読み込み中はローディングを表示し、未ログインユーザーはログインページへリダイレクトされるように変更。
- `AuthContext.tsx` に `isLoading` ステートを追加し、認証状態の読み込み中を管理。

## 確認方法

### 1. 自動テストによる確認 (必須)
フロントエンドのコンテナ内で以下のコマンドを実行し、すべてのテストがPASSすることを確認してください。
```bash
cd frontend && npm test
```

### 2. 手動による動作確認 (任意)
1. アプリケーションを起動し、ログインしてください。
2. ヘッダーに「マイページ」ボタンが表示されることを確認してください。
3. 「マイページ」ボタンをクリックし、マイページに遷移することを確認してください。
4. 登録済みのコーヒー豆がある場合、それらが一覧表示されることを確認してください。
5. 登録済みのコーヒー豆がない場合、「登録されている豆はありません。」というメッセージが表示されることを確認してください。
6. 未ログイン状態で `/my-beans` に直接アクセスした場合、ログインページにリダイレクトされることを確認してください。