### PR TITLE
48 featfrontend 商品編集ページの作成と更新機能の実装

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,12 @@
+import React, { useEffect } from 'react';
 import { Routes, Route, useNavigate } from 'react-router-dom';
 import BeanListPage from './pages/BeanListPage';
 import BeanDetailPage from './pages/BeanDetailPage';
 import NewBeanPage from './pages/NewBeanPage';
 import MyBeansPage from './pages/MyBeansPage';
+import EditBeanPage from './pages/EditBeanPage';
 import Login from './pages/Login';
 import { useAuth } from './contexts/AuthContext';
-import { useEffect } from 'react';
 import { Center, Loader } from '@mantine/core';
 import Layout from './components/Layout';
 
@@ -32,12 +33,20 @@ const App = () => {
             </RequireAuth>
           }
         />
+        <Route
+          path="beans/:beanId/edit"
+          element={
+            <RequireAuth>
+              <EditBeanPage />
+            </RequireAuth>
+          }
+        />
       </Route>
     </Routes>
   );
 };
 
-const RequireAuth = ({ children }: { children: JSX.Element }) => {
+const RequireAuth = ({ children }: { children: React.ReactElement }) => {
   const { session, isLoading } = useAuth();
   const navigate = useNavigate();
 

--- a/frontend/src/pages/BeanDetailPage.tsx
+++ b/frontend/src/pages/BeanDetailPage.tsx
@@ -18,6 +18,8 @@ interface BeanDetail {
   name: string;
   origin: string;
   price: number;
+  process: string;
+  roast_profile: string;
 }
 
 export default function BeanDetailPage() {
@@ -92,6 +94,8 @@ export default function BeanDetailPage() {
           <Text size="lg" c="dimmed" mt="xs">
             産地: {bean.origin}
           </Text>
+          <Text mt="sm">精製方法: {bean.process}</Text>
+          <Text mt="sm">焙煎度: {bean.roast_profile}</Text>
           <Text size="xl" fw={700} mt="md">
             {bean.price}円
           </Text>

--- a/frontend/src/pages/EditBeanPage.test.tsx
+++ b/frontend/src/pages/EditBeanPage.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { BrowserRouter } from 'react-router-dom';
+import { MantineProvider } from '@mantine/core';
+import { ModalsProvider } from '@mantine/modals';
+import type { Session } from '@supabase/supabase-js';
+import EditBeanPage from './EditBeanPage';
+import { AuthProvider } from '../contexts/AuthContext';
+import { supabase } from '../lib/supabaseClient';
+
+// Mocks
+vi.mock('../lib/supabaseClient');
+const mockNavigate = vi.fn();
+const mockUseParams = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => mockUseParams(),
+  };
+});
+
+window.fetch = vi.fn();
+window.alert = vi.fn(); // Mock window.alert
+
+const mockBean = {
+  id: 1,
+  name: 'Old Bean Name',
+  origin: 'Old Origin',
+  price: 1200,
+  process: 'washed',
+  roast_profile: 'medium',
+};
+
+const mockSession: Session = {
+  access_token: 'fake-test-token',
+  refresh_token: 'test-refresh-token',
+  expires_in: 3600,
+  token_type: 'bearer',
+  user: {
+    id: 'test-user',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: new Date().toISOString(),
+  },
+};
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(
+    <BrowserRouter>
+      <MantineProvider>
+        <ModalsProvider>
+          <AuthProvider>{ui}</AuthProvider>
+        </ModalsProvider>
+      </MantineProvider>
+    </BrowserRouter>
+  );
+};
+
+describe('EditBeanPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseParams.mockReturnValue({ beanId: '1' });
+    
+    // Mock supabase session
+    vi.mocked(supabase.auth.getSession).mockResolvedValue({
+      data: { session: mockSession },
+      error: null,
+    });
+    vi.mocked(supabase.auth.onAuthStateChange).mockReturnValue({
+        data: { subscription: { id: 'sub-id', callback: vi.fn(), unsubscribe: vi.fn() } },
+    });
+
+
+    // Mock the GET request for initial data fetching
+    vi.mocked(fetch).mockImplementation((url) => {
+      if (url === `/api/beans/1`) {
+        return Promise.resolve(
+          new Response(JSON.stringify(mockBean), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+  });
+
+  it('fetches bean data and populates the form', async () => {
+    renderWithProviders(<EditBeanPage />);
+
+    expect(await screen.findByDisplayValue('Old Bean Name')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Old Origin')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('1200')).toBeInTheDocument();
+    
+    const processSelect = screen.getByLabelText('精製方法');
+    expect(processSelect).toHaveValue('washed');
+
+    const roastSelect = screen.getByLabelText('焙煎度');
+    expect(roastSelect).toHaveValue('medium');
+  });
+
+  it('submits updated data and navigates on success', async () => {
+    // Mock the PUT request for submission
+    vi.mocked(fetch).mockImplementation((url, options) => {
+      if (url === '/api/beans/1' && options?.method === 'PUT') {
+        return Promise.resolve(
+          new Response(null, {
+            status: 204, // No Content
+          })
+        );
+      }
+      // Still need the GET mock for initial load
+      return Promise.resolve(
+        new Response(JSON.stringify(mockBean), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    });
+
+    renderWithProviders(<EditBeanPage />);
+
+    await screen.findByDisplayValue('Old Bean Name');
+
+    await userEvent.clear(screen.getByLabelText('名前'));
+    await userEvent.type(screen.getByLabelText('名前'), 'New Bean Name');
+    await userEvent.click(screen.getByRole('button', { name: '更新する' }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/beans/1', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${mockSession.access_token}`,
+        },
+        body: JSON.stringify({
+          name: 'New Bean Name',
+          origin: 'Old Origin',
+          price: 1200,
+          process: 'washed',
+          roast_profile: 'medium',
+        }),
+      });
+    });
+
+    expect(await screen.findByText('更新完了')).toBeInTheDocument();
+    
+    await userEvent.click(screen.getByRole('button', { name: 'OK' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/my-beans');
+  });
+
+  it('shows an error message if fetching initial data fails', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(null, { status: 500, statusText: 'Internal Server Error' })
+    );
+    renderWithProviders(<EditBeanPage />);
+    expect(await screen.findByText('エラー')).toBeInTheDocument();
+    expect(screen.getByText(/HTTP error!/)).toBeInTheDocument();
+  });
+
+  it('shows an error message if submission fails', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockBean), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: 'Update failed' }), { status: 500 })
+      );
+
+    renderWithProviders(<EditBeanPage />);
+    await screen.findByDisplayValue('Old Bean Name');
+
+    await userEvent.click(screen.getByRole('button', { name: '更新する' }));
+
+    expect(await screen.findByText('エラー')).toBeInTheDocument();
+    expect(screen.getByText('Update failed')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/EditBeanPage.tsx
+++ b/frontend/src/pages/EditBeanPage.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import {
+  Container,
+  Title,
+  TextInput,
+  NumberInput,
+  Select,
+  Button,
+  Box,
+  Alert,
+  Group,
+  Text,
+  Loader,
+  Center,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useModals } from '@mantine/modals';
+import { IconAlertCircle } from '@tabler/icons-react';
+import { useAuth } from '../contexts/AuthContext';
+
+interface BeanInput {
+  name: string;
+  origin: string;
+  price: number | '';
+  process: string;
+  roast_profile: string;
+}
+
+export default function EditBeanPage() {
+  const { beanId } = useParams<{ beanId: string }>();
+  const navigate = useNavigate();
+  const modals = useModals();
+  const { session } = useAuth();
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [pageLoading, setPageLoading] = useState<boolean>(true);
+
+  const form = useForm<BeanInput>({
+    initialValues: {
+      name: '',
+      origin: '',
+      price: '',
+      process: '',
+      roast_profile: '',
+    },
+    validate: {
+      name: (value) => (value.trim().length > 0 ? null : '名前を入力してください'),
+      origin: (value) => (value.trim().length > 0 ? null : '産地を入力してください'),
+      price: (value) => (value !== '' && Number(value) >= 0 ? null : '価格を0以上で入力してください'),
+      process: (value) => (value ? null : '精製方法を選択してください'),
+      roast_profile: (value) => (value ? null : '焙煎度を選択してください'),
+    },
+  });
+
+  useEffect(() => {
+    const fetchBean = async () => {
+      setPageLoading(true);
+      try {
+        const response = await fetch(`/api/beans/${beanId}`);
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data = await response.json();
+        form.setValues({
+          name: data.name,
+          origin: data.origin,
+          price: data.price,
+          process: data.process,
+          roast_profile: data.roast_profile,
+        });
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          setError(e.message);
+        } else {
+          setError('不明なエラーが発生しました。');
+        }
+      } finally {
+        setPageLoading(false);
+      }
+    };
+
+    fetchBean();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [beanId]);
+
+  const handleSubmit = async (values: BeanInput) => {
+    setLoading(true);
+    setError(null);
+
+    if (!session) {
+      alert('ログインが必要です。再度ログインしてください。');
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/beans/${beanId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({
+          ...values,
+          price: Number(values.price),
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
+      }
+
+      modals.openConfirmModal({
+        title: '更新完了',
+        centered: true,
+        children: (
+          <Text size="sm">
+            コーヒー豆の情報が正常に更新されました。
+          </Text>
+        ),
+        labels: { confirm: 'OK', cancel: '閉じる' },
+        cancelProps: { style: { display: 'none' } },
+        onConfirm: () => navigate('/my-beans'),
+      });
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError('不明なエラーが発生しました。');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (pageLoading) {
+    return (
+      <Center style={{ height: '50vh' }}>
+        <Loader />
+      </Center>
+    );
+  }
+
+  return (
+    <Container mt="xl">
+      <Title order={1} mb="lg">
+        コーヒー豆を編集
+      </Title>
+      <Box component="form" onSubmit={form.onSubmit(handleSubmit)}>
+        {error && (
+          <Alert icon={<IconAlertCircle size="1rem" />} title="エラー" color="red" mb="lg">
+            {error}
+          </Alert>
+        )}
+        <TextInput
+          label="名前"
+          placeholder="例：エチオピア イルガチェフェ"
+          mb="sm"
+          {...form.getInputProps('name')}
+        />
+        <TextInput
+          label="産地"
+          placeholder="例：エチオピア"
+          mb="sm"
+          {...form.getInputProps('origin')}
+        />
+        <NumberInput
+          label="価格"
+          placeholder="例：1500"
+          mb="sm"
+          min={0}
+          hideControls
+          {...form.getInputProps('price')}
+        />
+        <Select
+          label="精製方法"
+          placeholder="精製方法を選択してください"
+          mb="sm"
+          data={['natural', 'washed', 'honey']}
+          {...form.getInputProps('process')}
+        />
+        <Select
+          label="焙煎度"
+          placeholder="焙煎度を選択してください"
+          mb="xl"
+          data={['light','cinnamon','medium','high','city','full_city','french','italian']}
+          {...form.getInputProps('roast_profile')}
+        />
+        <Group>
+          <Button type="submit" loading={loading}>
+            更新する
+          </Button>
+          <Button component={Link} to="/my-beans" variant="outline">
+            キャンセル
+          </Button>
+        </Group>
+      </Box>
+    </Container>
+  );
+}

--- a/frontend/src/pages/MyBeansPage.test.tsx
+++ b/frontend/src/pages/MyBeansPage.test.tsx
@@ -110,7 +110,7 @@ describe('MyBeansPage', () => {
     });
 
     // 編集・削除ボタンが表示されていることを確認
-    expect(screen.getAllByRole('button', { name: '編集' })).toHaveLength(2);
+    expect(screen.getAllByRole('link', { name: '編集' })).toHaveLength(2);
     expect(screen.getAllByRole('button', { name: '削除' })).toHaveLength(2);
     expect(
       screen.getByRole('link', { name: '一覧に戻る' })

--- a/frontend/src/pages/MyBeansPage.tsx
+++ b/frontend/src/pages/MyBeansPage.tsx
@@ -113,7 +113,12 @@ export default function MyBeansPage() {
                   </Text>
                 </Link>
                 <Group>
-                  <Button size="xs" variant="outline">
+                  <Button
+                    component={Link}
+                    to={`/beans/${bean.id}/edit`}
+                    size="xs"
+                    variant="outline"
+                  >
                     編集
                   </Button>
                   <Button size="xs" variant="outline" color="red">


### PR DESCRIPTION
## 概要

出品したコーヒー豆の情報を編集するページを実装しました。
また、詳細画面で豆の情報がすべて表示されていなかったので、表示されるように修正しました。

## 関連イシュー

Closes #48

## 変更点

- **商品編集ページの作成**
  - 編集ページのルート (`/my/beans/:beanId/edit`) とコンポーネント (`EditBeanPage.tsx`) を新規作成。
  - ページ表示時に既存の豆情報を取得し、フォームに初期値として設定する機能を追加。
  - フォーム送信時に `PUT /api/beans/:beanId` エンドポイントに更新データを送信するロジックを実装。
  - 更新成功後はメッセージを表示して、マイページにリダイレクト。
  - 関連するテストコードを追加し、既存テストがすべてPASSすることを確認。

- **商品詳細ページの表示項目追加**
  - `BeanDetailPage.tsx` に「精製方法」と「焙煎度」の表示を追加。
  - バックエンドのAPIレスポンスに合わせて、フロントエンドの型定義を更新。

## 確認方法

### 1. 自動テストによる確認 (必須)

フロントエンドのコンテナ内で以下のコマンドを実行し、すべてのテストがPASSすることを確認してください。

```
npm test
```

### 2. 手動による動作確認 (任意)

1.  アプリケーションを起動し、ログインします。
2.  ヘッダーの「マイページ」ボタンからマイページに遷移します。
3.  自身が登録した豆のリストが表示されていることを確認し、いずれかの「編集」ボタンをクリックします。
4.  編集ページに遷移し、フォームに既存の豆情報が入力されていることを確認します。
5.  フォームの値をいくつか変更し、「更新する」ボタンをクリックします。
6.  成功メッセージ表示後、マイページにリダイレクトされ、情報が更新されていることを確認します。