### PR TITLE
feat(frontend): 商品詳細ページにカート追加機能を実装 (Closes #62)

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useState, useEffect } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import type { Session } from '@supabase/supabase-js';
 
-const AuthContext = createContext<{ session: Session | null; isLoading: boolean }>({ session: null, isLoading: true });
+export const AuthContext = createContext<{ session: Session | null; isLoading: boolean }>({ session: null, isLoading: true });
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [session, setSession] = useState<Session | null>(null);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App.tsx';
 import { MantineProvider } from '@mantine/core';
+import { Notifications } from '@mantine/notifications';
 import '@mantine/notifications/styles.css';
 import { ModalsProvider } from '@mantine/modals';
 import { AuthProvider } from './contexts/AuthContext.tsx';
@@ -12,6 +13,7 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
       <MantineProvider>
+        <Notifications />
         <AuthProvider>
           <ModalsProvider>
             <App />

--- a/frontend/src/pages/BeanDetailPage.test.tsx
+++ b/frontend/src/pages/BeanDetailPage.test.tsx
@@ -1,8 +1,21 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeAll, afterEach, afterAll, test, expect, vi } from 'vitest';
 import BeanDetailPage from './BeanDetailPage';
 import { MantineProvider } from '@mantine/core';
+import { Notifications } from '@mantine/notifications';
+import { AuthProvider, AuthContext } from '../contexts/AuthContext';
+import type { Session } from '@supabase/supabase-js';
+
+// useNavigateのモック
+const mockedNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockedNavigate,
+  };
+});
 
 // APIのモック設定
 const mockBeanDetail = {
@@ -10,39 +23,125 @@ const mockBeanDetail = {
   name: 'モック・エチオピア',
   origin: 'モック産地',
   price: 1500,
+  process: 'washed',
+  roast_profile: 'medium',
 };
 
-beforeAll(() => {
-  // fetchが呼ばれたら、常にmockBeanDetailを返すように設定
-  globalThis.fetch = vi.fn().mockResolvedValue({
-    ok: true,
-    json: () => Promise.resolve(mockBeanDetail),
-  });
+// 正常なレスポンスを返すfetchモック
+const mockFetchSuccess = vi.fn().mockResolvedValue({
+  ok: true,
+  json: () => Promise.resolve(mockBeanDetail),
 });
-afterEach(() => vi.clearAllMocks());
-afterAll(() => vi.restoreAllMocks());
 
-test('詳細データが正しく表示される', async () => {
-  const testId = '1';
+// 認証済みセッションのモック
+const mockSession = {
+  access_token: 'test-token',
+  user: { id: 'test-user-id' },
+} as unknown as Session;
 
-  // テスト用のルーターで、詳細ページのURLを直接指定
-  render(
+// テスト用のカスタムレンダー関数
+const renderWithProviders = (
+  ui: React.ReactElement,
+  { session = null, initialEntries = ['/beans/1'] }: { session?: Session | null, initialEntries?: string[] } = {}
+) => {
+  return render(
     <MantineProvider>
-      <MemoryRouter initialEntries={[`/beans/${testId}`]}>
-        <Routes>
-          <Route path="/beans/:beanId" element={<BeanDetailPage />} />
-        </Routes>
+      <MemoryRouter initialEntries={initialEntries}>
+        <AuthProvider>
+          <AuthContext.Provider value={{ session, isLoading: false }}>
+            <Notifications />
+            <Routes>
+              <Route path="/beans/:beanId" element={ui} />
+              <Route path="/login" element={<div>Login Page</div>} />
+            </Routes>
+          </AuthContext.Provider>
+        </AuthProvider>
       </MemoryRouter>
     </MantineProvider>
   );
+};
 
-  // API通信とレンダリングが完了し、豆の名前が表示されるのを待つ
+beforeAll(() => {
+  globalThis.fetch = mockFetchSuccess;
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  // 各テストの後にfetchをリセット
+  globalThis.fetch = mockFetchSuccess;
+});
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+test('詳細データが正しく表示される', async () => {
+  renderWithProviders(<BeanDetailPage />);
+
   expect(await screen.findByText(mockBeanDetail.name)).toBeInTheDocument();
-
-  // その他の情報も正しく表示されていることを確認
   expect(screen.getByText(`産地: ${mockBeanDetail.origin}`)).toBeInTheDocument();
   expect(screen.getByText(`${mockBeanDetail.price}円`)).toBeInTheDocument();
+  expect(mockFetchSuccess).toHaveBeenCalledWith('/api/beans/1');
+});
 
-  // APIが正しいIDで呼び出されたことを確認
-  expect(globalThis.fetch).toHaveBeenCalledWith(`/api/beans/${testId}`);
+test('未ログインで「カートに追加」をクリックするとログインページに遷移する', async () => {
+  renderWithProviders(<BeanDetailPage />, { session: null });
+
+  // カートに追加ボタンが表示されるのを待つ
+  const addToCartButton = await screen.findByRole('button', { name: /カートに追加/i });
+  fireEvent.click(addToCartButton);
+
+  // navigateが/loginで呼ばれたことを確認
+  expect(mockedNavigate).toHaveBeenCalledWith('/login');
+});
+
+test('ログイン済みで「カートに追加」をクリックするとAPIが呼ばれる', async () => {
+  renderWithProviders(<BeanDetailPage />, { session: mockSession });
+
+  const addToCartButton = await screen.findByRole('button', { name: /カートに追加/i });
+  const quantityInput = screen.getByLabelText('数量');
+
+  // 数量を2に変更
+  fireEvent.change(quantityInput, { target: { value: 2 } });
+
+  // APIモックをカート追加用に上書き
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ message: '成功' }),
+  });
+
+  fireEvent.click(addToCartButton);
+
+  // fetchが正しいエンドポイントとパラメータで呼ばれたか確認
+  await waitFor(() => {
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/cart/items', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${mockSession.access_token}`,
+      },
+      body: JSON.stringify({
+        bean_id: mockBeanDetail.id,
+        quantity: 2,
+      }),
+    });
+  });
+
+  // 成功通知が表示されることを確認
+  expect(await screen.findByText(`${mockBeanDetail.name}をカートに追加しました。`)).toBeInTheDocument();
+});
+
+test('カート追加APIが失敗した場合、エラー通知が表示される', async () => {
+  renderWithProviders(<BeanDetailPage />, { session: mockSession });
+
+  const addToCartButton = await screen.findByRole('button', { name: /カートに追加/i });
+
+  // APIモックをエラーを返すように上書き
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: false,
+    json: () => Promise.resolve({ message: '在庫がありません' }),
+  });
+
+  fireEvent.click(addToCartButton);
+
+  // エラー通知が表示されることを確認
+  expect(await screen.findByText('在庫がありません')).toBeInTheDocument();
 });


### PR DESCRIPTION
## 概要
商品詳細ページに「カートに追加」機能を実装しました。

##  関連イシュー

  Closes #62

 ## 変更点

   - 商品詳細ページ(BeanDetailPage.tsx)に数量選択フォームと「カートに追加」ボタンを設置
   - ログイン状態に応じて「カートに追加」ボタンの挙動を変更
     - ログイン済み: POST /api/cart/items APIを呼び出し、商品をカートに追加
     - 未ログイン: ログインページへリダイレクト
   - APIの実行結果に応じて、ユーザーに成功・失敗の通知を表示
   - 上記機能に関するテストコードをBeanDetailPage.test.tsxに追加・修正
   - アプリケーション全体で通知機能を利用可能にするため、main.tsxにNotificationsプロバイダーを追加
   - テストでAuthContextを正しく利用するため、AuthContext.tsxのAuthContextをエクスポートするように修正

##  確認方法

 ### 1. 自動テストによる確認 (必須)

  フロントエンドのサーバ内で以下のコマンドを実行し、すべてのテストがPASSすることを確認してください。

   ```npm test```

###  2. 手動による動作確認 (任意)

  - ステップ1: サーバーの起動
  バックエンドとフロントエンドのサーバーを起動します。

  - ステップ2: 商品詳細ページでの操作
   1. 未ログインの状態で商品詳細ページを開き、「カートに追加」ボタンをクリックすると、ログインページに遷移する
      ことを確認してください。
   2. ログイン後、再度商品詳細ページを開きます。
   3. 数量を指定し、「カートに追加」ボタンをクリックすると、「カートに追加しました」という成功通知が表示される
      ことを確認してください。
   4. 任意でcart_itemsテーブルに追加したコーヒー豆のレコードが追加されていることを確認してください。