### PR TITLE
feat(frontend): 決済処理機能と確認モーダルを実装 (Closes #79, 87)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,9 @@ import { useAuth } from './contexts/AuthContext';
 import { Center, Loader } from '@mantine/core';
 import Layout from './components/Layout';
 
+import { Elements } from '@stripe/react-stripe-js';
+import { stripePromise } from './lib/stripe';
+
 const App = () => {
   return (
     <Routes>
@@ -64,7 +67,9 @@ const App = () => {
           path="checkout/success"
           element={
             <RequireAuth>
-              <CheckoutSuccessPage />
+              <Elements stripe={stripePromise}>
+                <CheckoutSuccessPage />
+              </Elements>
             </RequireAuth>
           }
         />

--- a/frontend/src/components/CheckoutForm.test.tsx
+++ b/frontend/src/components/CheckoutForm.test.tsx
@@ -1,16 +1,30 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MantineProvider } from '@mantine/core';
 import CheckoutForm from './CheckoutForm';
 import { vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+// useNavigateのモック
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const original = await vi.importActual('react-router-dom');
+  return {
+    ...original,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 // Stripeのモック
 const mockConfirmPayment = vi.fn();
+const mockGetElement = vi.fn(() => document.createElement('div'));
 vi.mock('@stripe/react-stripe-js', () => ({
   PaymentElement: () => <div>Payment Element</div>,
   useStripe: () => ({
     confirmPayment: mockConfirmPayment,
   }),
-  useElements: () => ({}),
+  useElements: () => ({
+    getElement: mockGetElement,
+  }),
 }));
 
 const mockCartItems = [
@@ -22,13 +36,16 @@ const mockTotalPrice = 2500;
 describe('CheckoutForm', () => {
   beforeEach(() => {
     mockConfirmPayment.mockClear();
+    mockNavigate.mockClear();
     globalThis.fetch = vi.fn();
   });
 
   const renderComponent = () => {
     return render(
       <MantineProvider>
-        <CheckoutForm cartItems={mockCartItems} totalPrice={mockTotalPrice} />
+        <MemoryRouter>
+          <CheckoutForm cartItems={mockCartItems} totalPrice={mockTotalPrice} />
+        </MemoryRouter>
       </MantineProvider>
     );
   };
@@ -57,7 +74,110 @@ describe('CheckoutForm', () => {
     expect(screen.getByRole('button', { name: '支払う' })).toBeInTheDocument();
   });
 
-  test('郵便番号入力時に自動でハイフンが挿入される', () => {
+  test('決済成功時に完了ページに遷移する', async () => {
+    mockConfirmPayment.mockResolvedValue({
+      paymentIntent: { status: 'succeeded', client_secret: 'test_secret' },
+    });
+    renderComponent();
+
+    // フォームの必須項目を埋める
+    fireEvent.change(screen.getByPlaceholderText('焙煎 太郎'), { target: { value: 'テストユーザー' } });
+    fireEvent.change(screen.getByPlaceholderText('123-4567'), { target: { value: '123-4567' } });
+    fireEvent.change(screen.getByPlaceholderText('〇〇県'), { target: { value: '東京都' } });
+    fireEvent.change(screen.getByPlaceholderText('〇〇市'), { target: { value: '千代田区' } });
+    fireEvent.change(screen.getByPlaceholderText('1-1'), { target: { value: '丸の内1-1' } });
+    fireEvent.change(screen.getByPlaceholderText('000-1111-2222'), { target: { value: '09012345678' } });
+    fireEvent.change(screen.getByPlaceholderText('TARO BAISEN'), { target: { value: 'TEST TARO' } });
+
+    const payButtonInForm = screen.getByRole('button', { name: '支払う' });
+    fireEvent.click(payButtonInForm);
+
+    // モーダルが開くのを待つ
+    const modal = await screen.findByRole('dialog');
+    expect(modal).toBeInTheDocument();
+
+    // モーダル内の支払うボタンをクリック
+    const payButtonInModal = within(modal).getByRole('button', { name: '支払う' });
+    fireEvent.click(payButtonInModal);
+
+    await waitFor(() => {
+      expect(mockConfirmPayment).toHaveBeenCalled();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/checkout/success?payment_intent_client_secret=test_secret'
+    );
+  });
+
+  test('決済失敗時にエラーメッセージを表示する', async () => {
+    const errorMessage = 'Your card was declined.';
+    mockConfirmPayment.mockResolvedValue({ error: { type: 'card_error', message: errorMessage } });
+    renderComponent();
+
+    // フォームの必須項目を埋める
+    fireEvent.change(screen.getByPlaceholderText('焙煎 太郎'), { target: { value: 'テストユーザー' } });
+    fireEvent.change(screen.getByPlaceholderText('123-4567'), { target: { value: '123-4567' } });
+    fireEvent.change(screen.getByPlaceholderText('〇〇県'), { target: { value: '東京都' } });
+    fireEvent.change(screen.getByPlaceholderText('〇〇市'), { target: { value: '千代田区' } });
+    fireEvent.change(screen.getByPlaceholderText('1-1'), { target: { value: '丸の内1-1' } });
+    fireEvent.change(screen.getByPlaceholderText('000-1111-2222'), { target: { value: '09012345678' } });
+    fireEvent.change(screen.getByPlaceholderText('TARO BAISEN'), { target: { value: 'TEST TARO' } });
+
+    const payButtonInForm = screen.getByRole('button', { name: '支払う' });
+    fireEvent.click(payButtonInForm);
+
+    // モーダルが開くのを待つ
+    const modal = await screen.findByRole('dialog');
+    expect(modal).toBeInTheDocument();
+
+    // モーダル内の支払うボタンをクリック
+    const payButtonInModal = within(modal).getByRole('button', { name: '支払う' });
+    fireEvent.click(payButtonInModal);
+
+    await waitFor(() => {
+      expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  test('決済失敗時に予期せぬエラーが発生した場合、汎用エラーメッセージを表示する', async () => {
+    const errorMessage = 'An unexpected error occurred.';
+    mockConfirmPayment.mockResolvedValue({ error: { type: 'api_error', message: errorMessage } });
+    renderComponent();
+
+    // フォームの必須項目を埋める
+    fireEvent.change(screen.getByPlaceholderText('焙煎 太郎'), { target: { value: 'テストユーザー' } });
+    fireEvent.change(screen.getByPlaceholderText('123-4567'), { target: { value: '123-4567' } });
+    fireEvent.change(screen.getByPlaceholderText('〇〇県'), { target: { value: '東京都' } });
+    fireEvent.change(screen.getByPlaceholderText('〇〇市'), { target: { value: '千代田区' } });
+    fireEvent.change(screen.getByPlaceholderText('1-1'), { target: { value: '丸の内1-1' } });
+    fireEvent.change(screen.getByPlaceholderText('000-1111-2222'), { target: { value: '09012345678' } });
+    fireEvent.change(screen.getByPlaceholderText('TARO BAISEN'), { target: { value: 'TEST TARO' } });
+
+    const payButtonInForm = screen.getByRole('button', { name: '支払う' });
+    fireEvent.click(payButtonInForm);
+
+    // モーダルが開くのを待つ
+    const modal = await screen.findByRole('dialog');
+    expect(modal).toBeInTheDocument();
+
+    // モーダル内の支払うボタンをクリック
+    const payButtonInModal = within(modal).getByRole('button', { name: '支払う' });
+    fireEvent.click(payButtonInModal);
+
+    await waitFor(() => {
+      expect(screen.getByText('予期せぬエラーが発生しました。別のカードをお試しください。')).toBeInTheDocument();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  test('郵便番号入力時に自動でハイフンが挿入される', async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: 400, message: 'not found' }),
+    });
     renderComponent();
     const postalCodeInput = screen.getByPlaceholderText('123-4567');
 
@@ -66,19 +186,26 @@ describe('CheckoutForm', () => {
 
     fireEvent.change(postalCodeInput, { target: { value: '123-4567' } });
     expect(postalCodeInput.value).toBe('123-4567');
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalled();
+    });
   });
 
   test('有効な郵便番号入力時に住所が自動入力される', async () => {
     globalThis.fetch.mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({
-        status: 200,
-        results: [{
-          address1: '東京都',
-          address2: '千代田区',
-          address3: '丸の内',
-        }],
-      }),
+      json: () =>
+        Promise.resolve({
+          status: 200,
+          results: [
+            {
+              address1: '東京都',
+              address2: '千代田区',
+              address3: '丸の内',
+            },
+          ],
+        }),
     });
 
     renderComponent();
@@ -89,7 +216,9 @@ describe('CheckoutForm', () => {
     fireEvent.change(postalCodeInput, { target: { value: '100-0005' } });
 
     await waitFor(() => {
-      expect(globalThis.fetch).toHaveBeenCalledWith('https://zipcloud.ibsnet.co.jp/api/search?zipcode=1000005');
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'https://zipcloud.ibsnet.co.jp/api/search?zipcode=1000005'
+      );
       expect(prefectureInput.value).toBe('東京都');
       expect(cityInput.value).toBe('千代田区丸の内');
     });
@@ -117,5 +246,4 @@ describe('CheckoutForm', () => {
       expect(cityInput.value).toBe('');
     });
   });
-
 });

--- a/frontend/src/lib/stripe.ts
+++ b/frontend/src/lib/stripe.ts
@@ -1,0 +1,5 @@
+import { loadStripe } from '@stripe/stripe-js';
+
+export const stripePromise = loadStripe(
+  import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
+);

--- a/frontend/src/pages/CheckoutPage.tsx
+++ b/frontend/src/pages/CheckoutPage.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState } from 'react';
-import { loadStripe } from '@stripe/stripe-js';
+import { stripePromise } from '../lib/stripe';
 import { Elements } from '@stripe/react-stripe-js';
 import CheckoutForm from '../components/CheckoutForm';
 import { useAuth } from '../contexts/AuthContext';
 import { Center, Container, Loader, Alert } from '@mantine/core';
 
-// Stripeの公開可能キーを環境変数から読み込む
-const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY);
+
 
 // カートアイテムの型定義
 interface CartItem {

--- a/frontend/src/pages/CheckoutSuccessPage.test.tsx
+++ b/frontend/src/pages/CheckoutSuccessPage.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MantineProvider } from '@mantine/core';
+import { vi } from 'vitest';
+import CheckoutSuccessPage from './CheckoutSuccessPage';
+
+// useNavigateのモック
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const original = await vi.importActual('react-router-dom');
+  return {
+    ...original,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// Stripeのモック
+const mockRetrievePaymentIntent = vi.fn();
+vi.mock('@stripe/react-stripe-js', () => ({
+  useStripe: () => ({
+    retrievePaymentIntent: mockRetrievePaymentIntent,
+  }),
+}));
+
+const renderComponent = (initialEntry: string) => {
+  return render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/checkout/success" element={<CheckoutSuccessPage />} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>
+  );
+};
+
+describe('CheckoutSuccessPage', () => {
+  beforeEach(() => {
+    mockRetrievePaymentIntent.mockClear();
+    mockNavigate.mockClear();
+  });
+
+  test('client_secretがない場合、トップページにリダイレクトする', () => {
+    renderComponent('/checkout/success');
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+  });
+
+  test('決済が成功した場合(succeeded)、成功メッセージを表示する', async () => {
+    mockRetrievePaymentIntent.mockResolvedValue({
+      paymentIntent: { status: 'succeeded' },
+    });
+    renderComponent('/checkout/success?payment_intent_client_secret=test_secret');
+
+    await waitFor(() => {
+      expect(screen.getByText('ご購入ありがとうございます。お支払いが正常に完了しました。')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('link', { name: 'トップページに戻る' })).toBeInTheDocument();
+  });
+
+  test('決済が処理中の場合(processing)、処理中メッセージを表示する', async () => {
+    mockRetrievePaymentIntent.mockResolvedValue({
+      paymentIntent: { status: 'processing' },
+    });
+    renderComponent('/checkout/success?payment_intent_client_secret=test_secret');
+
+    await waitFor(() => {
+      expect(screen.getByText('決済処理中です。完了までしばらくお待ちください。')).toBeInTheDocument();
+    });
+    // ローダーが表示されていることを確認
+    expect(document.querySelector('.mantine-Loader-root')).toBeInTheDocument();
+  });
+
+  test('決済が失敗した場合(requires_payment_method)、エラーメッセージを表示する', async () => {
+    mockRetrievePaymentIntent.mockResolvedValue({
+      paymentIntent: { status: 'requires_payment_method' },
+    });
+    renderComponent('/checkout/success?payment_intent_client_secret=test_secret');
+
+    await waitFor(() => {
+      expect(screen.getByText('お支払いが失敗しました。お支払い方法をご確認の上、再度お試しください。')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('link', { name: 'カートに戻る' })).toBeInTheDocument();
+  });
+
+  test('予期せぬステータスの場合、汎用エラーメッセージを表示する', async () => {
+    mockRetrievePaymentIntent.mockResolvedValue({ paymentIntent: { status: 'canceled' } });
+    renderComponent('/checkout/success?payment_intent_client_secret=test_secret');
+
+    await waitFor(() => {
+      expect(screen.getByText('何らかの問題が発生しました。サポートにお問い合わせください。')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/CheckoutSuccessPage.tsx
+++ b/frontend/src/pages/CheckoutSuccessPage.tsx
@@ -1,14 +1,101 @@
-import { Container, Title, Text, Button } from '@mantine/core';
-import { Link } from 'react-router-dom';
+import { Container, Title, Text, Button, Loader, Alert, Center } from '@mantine/core';
+import { Link, useSearchParams, useNavigate } from 'react-router-dom';
+import { useStripe } from '@stripe/react-stripe-js';
+import { useEffect, useState } from 'react';
+import { IconCircleCheck, IconAlertCircle } from '@tabler/icons-react';
 
 export default function CheckoutSuccessPage() {
+  const stripe = useStripe();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [status, setStatus] = useState('loading');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const clientSecret = searchParams.get('payment_intent_client_secret');
+
+    if (!clientSecret) {
+      // URLにclient_secretがない場合はトップページにリダイレクト
+      navigate('/', { replace: true });
+      return;
+    }
+
+    if (!stripe) {
+      // Stripe.jsがまだ読み込まれていない場合は、次のeffectの実行を待つ
+      return;
+    }
+
+    stripe.retrievePaymentIntent(clientSecret).then(({ paymentIntent }) => {
+      switch (paymentIntent?.status) {
+        case 'succeeded':
+          setStatus('success');
+          setMessage('ご購入ありがとうございます。お支払いが正常に完了しました。');
+          break;
+        case 'processing':
+          setStatus('processing');
+          setMessage('決済処理中です。完了までしばらくお待ちください。');
+          break;
+        case 'requires_payment_method':
+          setStatus('error');
+          setMessage(
+            'お支払いが失敗しました。お支払い方法をご確認の上、再度お試しください。'
+          );
+          break;
+        default:
+          setStatus('error');
+          setMessage('何らかの問題が発生しました。サポートにお問い合わせください。');
+          break;
+      }
+    });
+  }, [stripe, searchParams]);
+
+  const renderContent = () => {
+    switch (status) {
+      case 'loading':
+        return <Loader />;
+      case 'success':
+        return (
+          <>
+            <IconCircleCheck size={80} color="teal" />
+            <Title order={2} mt="md">{message}</Title>
+            <Button component={Link} to="/" mt="xl">
+              トップページに戻る
+            </Button>
+          </>
+        );
+      case 'processing':
+        return (
+          <>
+            <Loader />
+            <Title order={3} mt="md">{message}</Title>
+            <Text c="dimmed" size="sm" mt="sm">
+              このページは自動的に更新されます。
+            </Text>
+          </>
+        );
+      case 'error':
+        return (
+          <>
+            <IconAlertCircle size={80} color="red" />
+            <Title order={3} mt="md">決済エラー</Title>
+            <Alert color="red" mt="lg">
+              {message}
+            </Alert>
+            <Button component={Link} to="/cart" mt="xl">
+              カートに戻る
+            </Button>
+          </>
+        );
+      default:
+        return null;
+    }
+  };
+
   return (
-    <Container style={{ textAlign: 'center' }} mt={100}>
-      <Title order={2}>お支払いありがとうございます！</Title>
-      <Text mt="md">ご注文が正常に完了しました。</Text>
-      <Button component={Link} to="/" mt="xl">
-        トップページに戻る
-      </Button>
+    <Container mt={100}>
+      <Center>
+        <div style={{ textAlign: 'center' }}>{renderContent()}</div>
+      </Center>
     </Container>
   );
 }


### PR DESCRIPTION
  ## 概要
  Stripe Payment Elementを利用した決済処理機能を実装しました。
  決済実行前に確認モーダルを表示し、ユーザーの誤操作を防ぎます。また、決済完了ページではStripeと連携して決済
  の最終ステータスを表示し、不正なページアクセスはトップページへリダイレクトするように修正しました。

  ## 関連イシュー
  Closes #79
  Closes #87

  ## 変更点
   - 決済フォームに確認モーダルを追加
   - stripe.confirmPayment を利用した決済実行ロジックを実装
   - 決済完了ページを、決済ステータスに応じて動的に表示するように修正
   - 決済完了ページへの直接アクセスを禁止し、トップページへリダイレクトするように変更
   - Stripeの初期化処理を共通化するリファクタリング
   - 上記変更に伴うテストコードの追加・修正

 ##  確認方法

###  1. 自動テストによる確認 (必須)
  フロントエンドのコンテナ内でnpm testを実行し、すべてのテストがPASSすることを確認してください。
`docker exec -w /workspaces/coffeebeans/frontend coffeebeans-frontend-1 npm test`

###  2. 手動による動作確認 (任意)

  ステップ1: バックエンドサーバ、フロントエンドサーバの起動

  ステップ2: 画面操作にて決済を実施
   1. 商品をカートに追加し、決済画面へ進みます。
   2. 配送先情報、支払い情報を入力します。
   3. 「支払う」ボタンをクリックすると、確認モーダルが表示されることを確認します。
   4. モーダル内の「支払う」ボタンをクリックし、テスト用のクレジットカード情報（成功テストカード番号例:4242424242424242）で決済を実行します。
   5. 決済が成功し、「ご購入ありがとうございます。お支払いが正常に完了しました。」と表示された決済完了ページへ
      遷移することを確認します。
   6. ブラウザのURLを直接 /checkout/success
      に書き換えてアクセスし、トップページへリダイレクトされることを確認します。
   7. 失敗パターンとして"失敗テスト用カード：4000000000000002"にて決済を実行し、決済が失敗しエラー内容が表示されることを確認してください。※他のテスト用カードはこちらに記載あり https://docs.stripe.com/testing?locale=ja-JP

  ステップ3:登録データの確認(Stripeアカウントデータの直接確認)
  Stripeのダッシュボードにログインし、「支払い」のページでテスト決済が成功していることを確認してください。